### PR TITLE
fix compilation warning.

### DIFF
--- a/substitute.el
+++ b/substitute.el
@@ -34,7 +34,7 @@
 ;;; Code:
 
 (require 'thingatpt)
-
+(require 'subr-x)
 (defgroup substitute nil
   "Efficiently replace targets in the buffer or context."
   :group 'editing)


### PR DESCRIPTION
when byte-compile this file without load subr-x, there is a warning
message, because if-let* is defined in subr-x
